### PR TITLE
[feat] 종목 리스트 추가 및 sharedworker 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,12 @@
     "deploy": "gh-pages -d dist"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.69.0",
     "chart.js": "^4.4.8",
     "lightweight-charts": "^5.0.3",
     "react": "^19.0.0",
     "react-chartjs-2": "^5.3.0",
+    "react-device-detect": "^2.2.3",
     "react-dom": "^19.0.0",
     "vite-plugin-svgr": "^4.3.0"
   },

--- a/src/bitCoinChart/api/CoinWebSocketManager.ts
+++ b/src/bitCoinChart/api/CoinWebSocketManager.ts
@@ -1,11 +1,5 @@
 import { CandlestickData, Time } from "lightweight-charts";
-
-type Subscriber = (data: CandlestickData[]) => void;
-
-type TradingData = {
-    price: number,
-    time: Time,
-}
+import { Subscriber, TradingData } from "../types/CoinTypes";
 
 /**
  * @symbol 코인 거래 종목
@@ -31,6 +25,7 @@ class CoinWebSocketManager {
         // const wsUrl = `wss://stream.binance.com:9443/ws/${this.symbol.toLowerCase()}@kline_${this.interval}`;
         // 실시간 trading 정보가져오는 url
         const wsUrl = `wss://stream.binance.com:9443/ws/${this.symbol.toLowerCase()}@trade`;
+        // const wsUrl = `wss://stream.binance.com:9443/ws/!ticker@arr`;
 
         // init 상황에서 이전 웹소켓이 있는경우 close
         if (this.ws) this.closeAll();

--- a/src/bitCoinChart/components/CoinAppWrapper.tsx
+++ b/src/bitCoinChart/components/CoinAppWrapper.tsx
@@ -1,0 +1,18 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Outlet } from "react-router-dom";
+import SymbolContextProvider from "../hooks/SymbolContextProvider";
+
+const queryClient = new QueryClient();
+
+function CoinAppWrapper() {
+  
+  return (
+      <QueryClientProvider client={queryClient}>
+        <SymbolContextProvider>
+          <Outlet />
+        </SymbolContextProvider>
+      </QueryClientProvider>
+  );
+}
+
+export default CoinAppWrapper;

--- a/src/bitCoinChart/components/CoinChart.tsx
+++ b/src/bitCoinChart/components/CoinChart.tsx
@@ -2,7 +2,7 @@ import React, { useContext, useEffect, useRef } from "react";
 import { createChart, CandlestickSeries, IChartApi } from "lightweight-charts";
 import { CoinWebSocketContext } from "../context/CoinWebSocketContext";
 import style from "../style/chart.module.scss";
-import { isMobile } from "../../utils/utils";
+import { isMobile } from "react-device-detect";
 
 const CoinChart: React.FC<{symbol: string}> = ({symbol}) => {
   const chartContainerRef = useRef<HTMLDivElement>(null);
@@ -15,7 +15,7 @@ const CoinChart: React.FC<{symbol: string}> = ({symbol}) => {
 
     const chart = createChart(chartContainerRef.current, {
       width: chartContainerRef.current.clientWidth,
-      height: isMobile() ? 250 : 500,
+      height: isMobile ? 250 : 500,
       layout: {
         background: { color: "#181818" },
         textColor: "#FFFFFF",
@@ -69,7 +69,7 @@ const CoinChart: React.FC<{symbol: string}> = ({symbol}) => {
 
   return (
     <div className={style.chart}>
-      <div ref={chartContainerRef} style={{ width: "100%", height: "100%" }} />
+      <div ref={chartContainerRef}/>
     </div>
 );
 };

--- a/src/bitCoinChart/components/CoinChartView.tsx
+++ b/src/bitCoinChart/components/CoinChartView.tsx
@@ -1,0 +1,55 @@
+import { ChangeEvent, useActionState, useEffect, useRef } from "react";
+import CoinWebSocketProvider from "../context/CoinWebSocketContext";
+import TradingViewChart from "./TradingViewChart";
+import style from "../style/chart.module.scss"
+import { useSymbol } from "../hooks/SymbolContextProvider";
+import CoinChart from "./CoinChart";
+
+const CoinChartView = () => {
+    const { symbolList, symbol, setSymbol} = useSymbol();
+    const selectRef = useRef<HTMLSelectElement>(null);
+
+    const [_, formAction] = useActionState((prevSymbol: string, formData: FormData) => {
+        const inputSymbol = formData.get("symbol") as string;
+        const newSymbol = inputSymbol.toUpperCase() + "USDT";
+
+        const isValid = symbolList.includes(newSymbol);
+
+        if (isValid) {
+            setSymbol(newSymbol);
+            return newSymbol;
+        } else {
+            alert(`${newSymbol} 은 유효하지 않습니다`);
+            return prevSymbol;
+        }
+    }, "ADAUSDT");
+
+    const handleOptionSelect = (e: ChangeEvent<HTMLSelectElement>) => {
+        setSymbol(e.target.value);
+    }
+
+    useEffect(() => {
+        if (selectRef.current) selectRef.current.value = symbol;
+    }, [symbol]);
+
+    return (
+        <div className={style.chartviewContainer}>
+                <form action={formAction}>
+                    <input name="symbol" type="text" placeholder="영어로 입력해라 ㅡㅡ"/>
+                    <button type="submit">조회</button>
+                    <label>{`현재 선택된 심볼: ${symbol}`}</label>
+                </form>
+                <select ref={selectRef} value={symbol} onChange={handleOptionSelect}>
+                    {symbolList.map(x => <option key={x} value={x}>{x}</option>)}
+                </select>
+                <CoinWebSocketProvider symbol={symbol}>
+                    <div className={style.chartwrapper}>
+                        <TradingViewChart symbol={symbol}/>
+                        <CoinChart symbol={symbol}/>
+                    </div>
+                </CoinWebSocketProvider>
+            </div>
+    )
+}
+
+export default CoinChartView;

--- a/src/bitCoinChart/components/CoinPriceList.tsx
+++ b/src/bitCoinChart/components/CoinPriceList.tsx
@@ -1,0 +1,32 @@
+import { useRef } from "react";
+import style from "../style/chart.module.scss";
+import { useNavigate } from "react-router-dom";
+import { isMobile } from "react-device-detect";
+import { useSymbol } from "../hooks/SymbolContextProvider";
+import useSymbolData from "../hooks/useSymbolData";
+
+const CoinPriceList = ({symbol}: {symbol: string}) => {
+    const { setSymbol } = useSymbol();
+    const { data } = useSymbolData(symbol);
+    const ref = useRef(null);
+    const navigator = useNavigate();
+
+    const handleClick = () => {
+        setSymbol(symbol);
+        if (isMobile) navigator('/chart/chartview');
+    }
+
+    return (
+        <div className={style.chartList} onClick={handleClick} ref={ref}>
+            <div>
+                <strong className={style.symbolListLabel}>{symbol.replace("USDT", "")}</strong>
+            </div>
+            <div style={{width: "100%", textAlign: "right"}}>
+                <strong className={style.price} style={{color: data?.color}}>{`${data?.price} `}</strong>
+                <strong className={style.price} style={{marginLeft: '10px'}}>{`USD`}</strong>
+            </div>
+        </div>
+    );
+}
+
+export default CoinPriceList;

--- a/src/bitCoinChart/components/TradingViewChart.tsx
+++ b/src/bitCoinChart/components/TradingViewChart.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from "react";
 import style from "../style/chart.module.scss"
-import { isMobile } from "../../utils/utils";
+import { isMobile } from "react-device-detect";
 
 /**
  * tradingView 차트 위젯을 통해 차트 구성
@@ -20,7 +20,7 @@ const TradingViewChart: React.FC<{symbol: string}> = ({symbol}) => {
         new window.TradingView.widget({
           container_id: "tradingview_chart",
           width: "100%",
-          height: isMobile() ? "250px" :"500px",
+          height: isMobile ? "250px" :"500px",
           symbol: `BINANCE:${symbol}`,
           interval: "1",
           timezone: "Etc/UTC",

--- a/src/bitCoinChart/hooks/SymbolContextProvider.tsx
+++ b/src/bitCoinChart/hooks/SymbolContextProvider.tsx
@@ -1,0 +1,32 @@
+import { createContext, ReactNode, useContext, useEffect, useState } from "react";
+
+export const SymbolContext = createContext<{ symbol: string; setSymbol: (value: string) => void; symbolList: string[]; setSymbolList: (value: string[]) => void; worker: SharedWorker  } | null>(null);
+
+export const useSymbol = () => {
+  const context = useContext(SymbolContext);
+  if (!context) {
+    throw new Error("useCount must be used within a CountProvider");
+  }
+  return context;
+};
+
+const worker = new SharedWorker(new URL('../worker/CoinSharedWorker.js', import.meta.url), {type: "module"});
+
+const SymbolContextProvider = ({ children }: { children: ReactNode }) => {
+    const [symbol, setSymbol] = useState<string>("ADAUSDT");
+    const [symbolList, setSymbolList] = useState<string[]>([]);
+
+    useEffect(() => {
+      return () => {
+        worker.port.close();
+      }
+    }, []);
+  
+    return (
+      <SymbolContext value={{ symbol, setSymbol, symbolList, setSymbolList, worker}}>
+        {children}
+      </SymbolContext>
+    );
+  };
+
+export default SymbolContextProvider;

--- a/src/bitCoinChart/hooks/useSymbolData.tsx
+++ b/src/bitCoinChart/hooks/useSymbolData.tsx
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query"
+import { CurrentPriceData } from "../types/CoinTypes";
+
+const useSymbolData = (symbol: string) => {
+    return useQuery<CurrentPriceData | null>({
+        queryKey: ["symbol", symbol],
+        queryFn: async () => null,
+        initialData: null,
+    })
+}
+
+export default useSymbolData;

--- a/src/bitCoinChart/style/chart.module.scss
+++ b/src/bitCoinChart/style/chart.module.scss
@@ -17,3 +17,49 @@
         width: 100%;
     }
 }
+
+.chartList {
+    align-items: center;
+    box-sizing: border-box;
+    display: flex;
+    min-height: 51px;
+    overflow: hidden;
+    padding: 8px 14px 8px 26px;
+    justify-content: space-between;
+    border-bottom: 1px solid #9a9898c1;
+
+    :hover {
+        cursor: pointer;
+    }
+}
+
+.symbolListLabel {
+    font-size: 11px;
+}
+
+.price {
+    display: inline-block;
+    font-size: 12px;
+    line-height: 16px;
+    position: relative;
+    word-break: break-all;
+}
+
+.app {
+    height: calc(100svh - 120px);
+    display: flex;
+    flex-direction: row;
+    overflow: hidden;
+}
+
+.listContainer {
+    display: flex;
+    flex-direction: column;
+    overflow-y: scroll;
+    overflow-x: hidden;
+
+}
+
+.chartviewContainer {
+    width: 100%;
+}

--- a/src/bitCoinChart/types/CoinTypes.ts
+++ b/src/bitCoinChart/types/CoinTypes.ts
@@ -1,0 +1,13 @@
+import { CandlestickData, Time } from "lightweight-charts";
+
+export type Subscriber = (data: CandlestickData[]) => void;
+
+export type TradingData = {
+    price: number,
+    time: Time,
+}
+
+export type CurrentPriceData = {
+    price: number,
+    color: string,
+}

--- a/src/bitCoinChart/worker/CoinSharedWorker.js
+++ b/src/bitCoinChart/worker/CoinSharedWorker.js
@@ -1,0 +1,74 @@
+// shared-worker.js
+const connections = [];
+const priceMap = {};
+const wsUrl = `wss://stream.binance.com:9443/ws/!ticker@arr`;
+let ws = null;
+let resultData = null;
+
+const connectWebSocket = () => {
+  console.log('실행완료');
+    ws = new WebSocket(wsUrl);
+
+    ws.onmessage = (event) => {
+        const json = JSON.parse(event.data);
+        connections.forEach((port) => {
+          port.postMessage(json);
+        });
+        const symbolFilterArr = Array.from(json).filter(x => x.s.includes("USDT"));
+        
+        // 변경이 있는 데이터만 전송해주므로 따로 효율화 할 필요 없음
+        symbolFilterArr.forEach(x => {
+          let color = '#FFFFFF';
+            if (priceMap[x.s] > x.o) {
+              color = "#f75467";
+            } else if (priceMap[x.s] < x.o) {
+              color = "#4386f9";
+            }
+            priceMap[x.s] = {price: parseFloat(x.c).toString(), color: color};
+        });
+
+        connections.forEach((port) => {
+          port.postMessage(priceMap);
+        });
+    };
+
+    ws.onclose = (event) => {
+      connections.forEach((port) => {
+        port.postMessage('연결 끊김');
+      });
+    };
+}
+
+self.onconnect = (event) => {
+  const port = event.ports[0]; // 새로 연결된 클라이언트의 포트
+  connections.push(port);
+
+  console.log("새로운 클라이언트 연결됨. 총 클라이언트 수:", connections.length);
+
+  // 클라이언트에서 받은 메시지 처리
+  port.onmessage = (e) => {
+    console.log("Received from client:", e.data);
+
+    // 모든 연결된 클라이언트에게 메시지 브로드캐스트
+    connections.forEach((clientPort) => {
+      clientPort.postMessage(`서버에서 받은 메시지: ${e.data}`);
+    });
+  };
+
+  // 연결된 클라이언트에게 초기 메시지 전송
+    port.postMessage(JSON.stringify(resultData));
+
+    connections.forEach((port) => {
+      port.postMessage('유저가 추가됨');
+    });
+
+  port.start(); // 반드시 start() 호출해야 메시지 전송 가능
+};
+
+self.onclose = (event) => {
+  connections.forEach((port) => {
+    port.postMessage('연결 끊김');
+  });
+}
+
+connectWebSocket();

--- a/src/components/ProjectRouter.tsx
+++ b/src/components/ProjectRouter.tsx
@@ -2,7 +2,10 @@ import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import ProjectNavigator from './ProjectNavigator';
 import Header from './Header';
 import StopWatch from '../stopwatch/components/Stopwatch';
+import CoinAppWrapper from '../bitCoinChart/components/CoinAppWrapper';
 import CoinApp from '../bitCoinChart/components/CoinApp';
+import CoinChartView from '../bitCoinChart/components/CoinChartView';
+import { isMobile } from 'react-device-detect';
 
 /**
  * 라우터
@@ -15,7 +18,10 @@ const ProjectRouter = () => {
                 <Routes>
                     <Route path='/' element={<ProjectNavigator/>}/>
                     <Route path='/stopwatch' element={<StopWatch/>}/>
-                    <Route path='/chart' element={<CoinApp/>}/>
+                    <Route path='/chart' element={<CoinAppWrapper/>}>
+                        <Route index element={<CoinApp />} />
+                        {isMobile && <Route path="chartview" element={<CoinChartView />} />}
+                    </Route>
                 </Routes>
             </div>
         </BrowserRouter>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,7 @@
-import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.scss'
 import ProjectRouter from './components/ProjectRouter.tsx'
 
 createRoot(document.getElementById('root')!).render(
-  <StrictMode>
     <ProjectRouter />
-  </StrictMode>,
 )

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,3 +1,0 @@
-export function isMobile() {
-    return window.innerWidth <= 768;
-}


### PR DESCRIPTION
- 종목리스트를 웹뷰: 왼쪽, 모바일: 화면 전체 로 출력되도록처리
- 종목 리스트는 현재 거래 상황을 실시간으로 반영하도록 처리
- Websocket을 통신을 통해 종목 거래 데이터를 실시간으로 받아오며 브라우저 탭을 통해 여러개 열 경우 websocket 연결을 줄이기 위해 sharedWorker사용
- outlet을 통한 중첩 router 를 통해 coin project 내에서 라우팅이 되도록 처리
- 모바일 환경에서만 종목리스트와 종목 차트가 다른 페이지로 출력되도록 구현
- 전체적인 state 및 prop 구조 변경 symbolContext 추가
- bug: 뒤로가기시 sharedWorker가 종료되는 문제 수정 (coinapp 에서 effect cleanup에서 close 처리되어 context로 옮기고 chart앱내에서 글로벌하게 관리도도록 처리)
- 모바일 UI 개선 및 mobile 인지 파악하기 위해 react-device-detect lib 추가
- state 관리 개선을 위해 @tanstack/react-query 를 사용하여 sharedworker로 받아온 데이터를 관리하도록 처리
- ToDo. coinWebSocketManager의 역할이 불문명해져서 제거하고 react-query의 상태를 사용할 수 있는지 검토