### PR TITLE
[feat] 종목 현재가 리스트에 시가기준 변동 퍼센트와 빨강 파랑으로 오르내림 체크가능하도록 처리

### DIFF
--- a/src/bitCoinChart/components/CoinApp.tsx
+++ b/src/bitCoinChart/components/CoinApp.tsx
@@ -14,25 +14,31 @@ const CoinApp: React.FC = () => {
     useEffect(() => {
         worker.port.onmessage = (event: MessageEvent) => {
             const symbolsData = event.data;
-            Object.entries(symbolsData).forEach(([symbol, data]) => {
-                queryClient.setQueryData(["symbol", symbol], data);
-            });
+            if (symbolsData?.type === 'data') {
+              Object.entries(symbolsData.data).forEach(([symbol, data]) => {
+                  queryClient.setQueryData(["symbol", symbol], data);
+              });
+              if (symbolList.length === 0) {
+                setSymbolList(Object.keys(symbolsData.data));
+              }
+              console.log(event.data);
+            }
         };
 
-        const fetchSymbols = async () => {
-            try {
-              const response = await fetch("https://api.binance.com/api/v3/exchangeInfo");
-              const data = await response.json();
-              if (data.symbols) {
-                const symbolList = data.symbols.filter(({symbol, status}: { symbol: string, status: string }) => symbol.includes("USDT") && status === "TRADING").map((symbol: { symbol: string }) => symbol.symbol);
-                setSymbolList(symbolList);
-              }
-            } catch (error) {
-              console.error("Error fetching Binance symbols:", error);
-            }
-          };
+        // const fetchSymbols = async () => {
+        //     try {
+        //       const response = await fetch("https://api.binance.com/api/v3/exchangeInfo");
+        //       const data = await response.json();
+        //       if (data.symbols) {
+        //         const symbolList = data.symbols.filter(({symbol, status}: { symbol: string, status: string }) => symbol.includes("USDT") && status === "TRADING").map((symbol: { symbol: string }) => symbol.symbol);
+        //         setSymbolList(symbolList);
+        //       }
+        //     } catch (error) {
+        //       console.error("Error fetching Binance symbols:", error);
+        //     }
+        //   };
 
-          fetchSymbols();
+        //   fetchSymbols();
     }, []);
 
 

--- a/src/bitCoinChart/components/CoinPriceList.tsx
+++ b/src/bitCoinChart/components/CoinPriceList.tsx
@@ -15,6 +15,11 @@ const CoinPriceList = ({symbol}: {symbol: string}) => {
         setSymbol(symbol);
         if (isMobile) navigator('/chart/chartview');
     }
+    // 기본값 처리
+    const price = data?.price ?? 0;
+    const openPrice = data?.openPrice ?? 1; // 0으로 두면 NaN 발생 가능하므로 1 사용
+    const priceChange = price === 0 ? 0 : ((price - openPrice) / openPrice * 100).toFixed(2);
+    const color = data?.color ?? "#FFFFFF"; // 기본 색상 지정
 
     return (
         <div className={style.chartList} onClick={handleClick} ref={ref}>
@@ -22,7 +27,8 @@ const CoinPriceList = ({symbol}: {symbol: string}) => {
                 <strong className={style.symbolListLabel}>{symbol.replace("USDT", "")}</strong>
             </div>
             <div style={{width: "100%", textAlign: "right"}}>
-                <strong className={style.price} style={{color: data?.color}}>{`${data?.price} `}</strong>
+                <strong className={style.price} style={{color: color}}>{`${price}`}</strong>
+                <strong className={style.price} style={{color: color, marginLeft: '10px'}}>{`${priceChange}% `}</strong>
                 <strong className={style.price} style={{marginLeft: '10px'}}>{`USD`}</strong>
             </div>
         </div>

--- a/src/bitCoinChart/types/CoinTypes.ts
+++ b/src/bitCoinChart/types/CoinTypes.ts
@@ -10,4 +10,5 @@ export type TradingData = {
 export type CurrentPriceData = {
     price: number,
     color: string,
+    openPrice: number,
 }

--- a/src/bitCoinChart/worker/CoinSharedWorker.js
+++ b/src/bitCoinChart/worker/CoinSharedWorker.js
@@ -4,39 +4,107 @@ const priceMap = {};
 const wsUrl = `wss://stream.binance.com:9443/ws/!ticker@arr`;
 let ws = null;
 let resultData = null;
+let fillOpenPrice = false;
+
+const BINANCE_API_URL = "https://api.binance.com/api/v3";
+
+// 1. 모든 종목 리스트 가져오기 (USDT 페어만 필터링)
+async function getAllSymbols() {
+    try {
+        const response = await fetch(`${BINANCE_API_URL}/exchangeInfo`);
+        const data = await response.json();
+
+        if (!data.symbols) {
+            throw new Error("Failed to fetch symbols list");
+        }
+
+        // USDT 마켓에 해당하는 종목만 필터링
+        const symbols = data.symbols
+            .filter((s) => s.symbol.endsWith("USDT")) // USDT 페어만 가져오기
+            .map((s) => s.symbol);
+
+        return symbols;
+    } catch (error) {
+        console.error("Error fetching symbols list:", error);
+        return [];
+    }
+}
+
+// 2. 특정 종목의 한국시간 9시 시가(open price) 가져오기
+async function getOpenPrice(symbol) {
+    const url = `${BINANCE_API_URL}/klines?symbol=${symbol}&interval=1d&limit=2`;
+
+    try {
+        const response = await fetch(url);
+        const data = await response.json();
+
+        if (!Array.isArray(data) || data.length < 2) {
+            throw new Error(`No sufficient data for ${symbol}`);
+        }
+
+        // 어제의 open price (1d 캔들의 시작가)
+        const openPrice = data[0][1];
+
+        return { symbol, openPrice };
+    } catch (error) {
+        console.error(`Error fetching data for ${symbol}:`, error);
+        return { symbol, openPrice: null };
+    }
+}
+
+// 3. 모든 종목의 9시 시가 가져오기
+async function fetchAllOpenPrices() {
+    const symbols = await getAllSymbols();
+    
+    if (symbols.length === 0) {
+        console.error("No symbols available.");
+        return;
+    }
+
+    console.log(`Fetching open prices for ${symbols.length} symbols...`);
+
+    const results = await Promise.all(symbols.map(getOpenPrice));
+    results.forEach(x => {
+      priceMap[x.symbol] = {price: parseFloat(x.openPrice).toString(), color: '#FFFFFF', openPrice: parseFloat(x.openPrice).toString()}
+    });
+}
+
+// websocket 실행 전에 호출해서 openPrice 세팅
+fetchAllOpenPrices();
+
 
 const connectWebSocket = () => {
   console.log('실행완료');
-    ws = new WebSocket(wsUrl);
+  ws = new WebSocket(wsUrl);
 
-    ws.onmessage = (event) => {
-        const json = JSON.parse(event.data);
-        connections.forEach((port) => {
-          port.postMessage(json);
-        });
-        const symbolFilterArr = Array.from(json).filter(x => x.s.includes("USDT"));
-        
-        // 변경이 있는 데이터만 전송해주므로 따로 효율화 할 필요 없음
-        symbolFilterArr.forEach(x => {
-          let color = '#FFFFFF';
-            if (priceMap[x.s] > x.o) {
-              color = "#f75467";
-            } else if (priceMap[x.s] < x.o) {
-              color = "#4386f9";
-            }
-            priceMap[x.s] = {price: parseFloat(x.c).toString(), color: color};
-        });
-
-        connections.forEach((port) => {
-          port.postMessage(priceMap);
-        });
-    };
-
-    ws.onclose = (event) => {
+  ws.onmessage = (event) => { 
+      const json = JSON.parse(event.data);
+      const symbolFilterArr = Array.from(json).filter(x => x.s.includes("USDT"));
       connections.forEach((port) => {
-        port.postMessage('연결 끊김');
+        port.postMessage({type: 'data', data: priceMap});
       });
-    };
+      // 변경이 있는 데이터만 전송해주므로 따로 효율화 할 필요 없음
+      symbolFilterArr.forEach(x => {
+        let color = '#FFFFFF';
+          if (parseFloat(priceMap[x.s].openPrice) < parseFloat(x.c)) {
+            color = "#f75467";
+          } else if (parseFloat(priceMap[x.s].openPrice) > parseFloat(x.c)) {
+            color = "#4386f9";
+          }
+          priceMap[x.s].price = parseFloat(x.c).toString();
+          priceMap[x.s].color = color;
+      });
+
+      connections.forEach((port) => {
+        port.postMessage({type: 'data', data: priceMap});
+      });
+  };
+
+  ws.onclose = (event) => {
+    connections.forEach((port) => {
+      port.postMessage('연결 끊김');
+    });
+  };
 }
 
 self.onconnect = (event) => {


### PR DESCRIPTION
- sharedworker에서 websocket실행 전 fetch 를 통해 종목별 한국시간 오전9시 기준 시가체크하여 data 구성
- coinApp에서 useEffect fetch로 받아오던 종목 리스트를 sharedworker의 webscoket정보를 토대로 react-query data 구성할때 setSymbolList가 가능하도록 하여 fetch 수 줄임