### PR TITLE
[bugfix] 어제의 시가를 가져오는 문제 수정

### DIFF
--- a/src/bitCoinChart/worker/CoinSharedWorker.js
+++ b/src/bitCoinChart/worker/CoinSharedWorker.js
@@ -43,7 +43,7 @@ async function getOpenPrice(symbol) {
         }
 
         // 어제의 open price (1d 캔들의 시작가)
-        const openPrice = data[0][1];
+        const openPrice = data.length >= 2 ? data[1][1] : data[0][1];
 
         return { symbol, openPrice };
     } catch (error) {


### PR DESCRIPTION
- data[0][1]은 어제의 시가를 가져옴, 오늘의시가는 data[1][1]이므로 오늘의 시가를 가져오도록 처리
- 만약 시간적으로 오늘의 시가가 아직 생성되지않은경우 [0][1]을 반환하도록 처리