### PR TITLE
[feat] 차트 프로제트 기능 추가 및 코드정리

### DIFF
--- a/src/bitCoinChart/components/CoinChart.tsx
+++ b/src/bitCoinChart/components/CoinChart.tsx
@@ -14,7 +14,7 @@ type CoinChartProps = {
  */
 const CoinChart: React.FC<CoinChartProps> = ({ symbol }) => {
   const chartContainerRef = useRef<HTMLDivElement>(null);
-  const candleData = useContext(CoinWebSocketContext);
+  const managerData = useContext(CoinWebSocketContext);
   const seriesRef = useRef<any>(null);
   const chartRef = useRef<IChartApi | null>(null);
 
@@ -75,8 +75,8 @@ const CoinChart: React.FC<CoinChartProps> = ({ symbol }) => {
   }, [symbol]);
 
   useEffect(() => {
-    seriesRef.current.setData(candleData);
-  }, [candleData]);
+    seriesRef.current.setData(managerData.candleData);
+  }, [managerData]);
 
   return (
     <div className={style.chart}>

--- a/src/bitCoinChart/components/CoinChartView.tsx
+++ b/src/bitCoinChart/components/CoinChartView.tsx
@@ -1,11 +1,13 @@
 import { ChangeEvent, useActionState, useEffect, useRef } from "react";
 import CoinWebSocketProvider from "../context/CoinWebSocketContext";
 import TradingViewChart from "./TradingViewChart";
-import style from "../style/chart.module.scss"
+import style from "../style/chart.module.scss";
 import { useSymbol } from "../hooks/SymbolContextProvider";
 import CoinChart from "./CoinChart";
 import { OrderBook } from "./OrderBook";
 import { isMobile } from "react-device-detect";
+import CoinMobileTab from "./CoinMobileTab";
+import TradeHitory from "./TradeHitory";
 
 /**
  * 차트 제공 UI
@@ -40,7 +42,7 @@ const CoinChartView = () => {
     }, [symbol]);
 
     return (
-        <div className={`${style.chartviewContainer}`} style={{paddingLeft: isMobile ? '0px' : '15px'}}>
+        isMobile ? <CoinMobileTab symbol={symbol}/> : <div className={`${style.chartviewContainer}`} style={{paddingLeft: isMobile ? '0px' : '15px'}}>
                 <form action={formAction}>
                     <input name="symbol" type="text" placeholder="영어로 입력 (ex: BTC)"/>
                     <button type="submit">조회</button>
@@ -53,10 +55,15 @@ const CoinChartView = () => {
                         <CoinWebSocketProvider symbol={symbol}>
                             <div className={style.chartwrapper}>
                                 <TradingViewChart symbol={symbol}/>
-                                    <CoinChart symbol={symbol}/>
+                                <CoinChart symbol={symbol}/>
                             </div>
-                            <div>
-                                <OrderBook symbol={symbol}/>
+                            <div style={{flexDirection: 'row', display: 'flex'}}>
+                                <div style={{minWidth: '300px'}}>
+                                    <OrderBook symbol={symbol}/>
+                                </div>
+                                <div style={{minWidth: '300px', marginLeft: '20px'}}>
+                                    <TradeHitory symbol={symbol}/>
+                                </div>
                             </div>
                         </CoinWebSocketProvider>
                     </div>

--- a/src/bitCoinChart/components/CoinMobileTab.tsx
+++ b/src/bitCoinChart/components/CoinMobileTab.tsx
@@ -1,0 +1,62 @@
+import { useState } from "react";
+import CoinWebSocketProvider from "../context/CoinWebSocketContext";
+import style from "../style/chart.module.scss"
+import TradingViewChart from "./TradingViewChart";
+import CoinChart from "./CoinChart";
+import { OrderBook } from "./OrderBook";
+import TradeHitory from "./TradeHitory";
+
+const TABS = ["차트", "호가", "시세"] as const;
+
+type Tab = typeof TABS[number];
+
+type CoinMobileTabProps = {
+    symbol: string;
+  }
+  
+
+const CoinMobileTab: React.FC<CoinMobileTabProps> = ({ symbol }) => {
+  const [activeTab, setActiveTab] = useState<Tab>("차트");
+
+  return (
+    <div className="w-full" style={{width: '100%'}}>
+      <div>
+        {symbol}
+      </div>
+      <div className="flex" style={{display: "flex"}}>
+        {TABS.map((tab) => (
+          <div
+            key={tab}
+            onClick={() => setActiveTab(tab)}
+            className={style.tab}
+            style={activeTab === tab ? {backgroundColor: 'rgb(0, 0, 0)'} : {}}
+          >
+            {tab}
+          </div>
+        ))}
+      </div>
+
+      {/* 탭 컨텐츠 */}
+        <div className="p-4" style={{display: "flex", marginTop: '10px'}}>
+            <div style={{flex: '1'}}>
+                <CoinWebSocketProvider symbol={symbol}>
+                    {activeTab === "호가" && 
+                        <OrderBook symbol={symbol}/>
+                    }
+                    {activeTab === "차트" && 
+                        <div className={style.chartwrapper}>
+                                <TradingViewChart symbol={symbol}/>
+                                <CoinChart symbol={symbol}/>
+                        </div>
+                    }
+                    {activeTab === "시세" && 
+                        <TradeHitory symbol={symbol}/>
+                    }
+                </CoinWebSocketProvider>
+            </div>
+        </div>
+    </div>
+  );
+};
+
+export default CoinMobileTab;

--- a/src/bitCoinChart/components/OrderBook.tsx
+++ b/src/bitCoinChart/components/OrderBook.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState, useRef, useContext } from 'react';
 import { CoinWebSocketContext } from '../context/CoinWebSocketContext';
-import { CandlestickData } from 'lightweight-charts';
 import style from '../style/chart.module.scss';
 import { BINANCE_URL } from '../types/CoinTypes';
 
@@ -18,7 +17,7 @@ export const OrderBook: React.FC<OrderBookProps> = ({ symbol }) => {
   const socketRef = useRef<WebSocket | null>(null);
   const red = '#f75467';
   const blue = '#4386f9';
-  const candleData: CandlestickData[] = useContext(CoinWebSocketContext);
+  const { candleData } = useContext(CoinWebSocketContext);
   const lastPrice = candleData.at(-1)?.close;
 
   // 최대 수량 계산 (비율 바를 위해)

--- a/src/bitCoinChart/components/TradeHitory.tsx
+++ b/src/bitCoinChart/components/TradeHitory.tsx
@@ -1,0 +1,48 @@
+import { CoinWebSocketContext } from '../context/CoinWebSocketContext';
+import { useContext } from 'react';
+import useSymbolData from '../hooks/useSymbolData';
+import style from '../style/Tradinghitory.module.scss';
+import { convertKrTime } from '../utils/util';
+
+type TradeHitoryProps = {
+    symbol: string;
+}
+
+const TradeHitory: React.FC<TradeHitoryProps> = ({ symbol }) => {
+    const { tradeHistory } = useContext(CoinWebSocketContext);
+    const { data } = useSymbolData(symbol);
+    const red = '#f75467';
+    const blue = '#4386f9';
+    const openPrice = data?.openPrice ?? 0;
+
+    return (
+        <div className={style.table}>
+            <table style={{width: "100%", textAlign: "center", border: '1px solid #eee', borderCollapse: 'collapse'}}>
+                <thead>
+                    <tr>
+                        <td>
+                            체결시간
+                        </td>
+                        <td>
+                            {'체결가격(USD)'}
+                        </td>
+                        <td>
+                            {'체결량(AUCTION)'}
+                        </td>
+                    </tr>
+                </thead>
+                <tbody>
+                    {tradeHistory?.map(trade => 
+                        <tr key={trade.id}>
+                            <td>{convertKrTime(trade.time)}</td>
+                            <td style={trade.price > openPrice ? {color: red} : {color: blue}}>{trade.price}</td>
+                            <td style={trade.maker ? {color: red} : {color: blue}}>{trade.mount}</td>
+                        </tr>
+                    )}
+                </tbody>
+            </table>
+        </div>
+    )
+}
+
+export default TradeHitory;

--- a/src/bitCoinChart/context/CoinWebSocketContext.tsx
+++ b/src/bitCoinChart/context/CoinWebSocketContext.tsx
@@ -1,9 +1,9 @@
 import React, { createContext, useEffect, useState, ReactNode, useRef } from "react";
 import CoinWebSocketManager from '../api/CoinWebSocketManager'
-import { CandlestickData } from "lightweight-charts";
+import { CoinManagerData } from "../types/CoinTypes";
 
 // Context 생성
-export const CoinWebSocketContext = createContext<CandlestickData[]>([]);
+export const CoinWebSocketContext = createContext<CoinManagerData>({candleData: [], tradeHistory: []});
 
 interface CoinWebSocketProviderProps {
     symbol: string;
@@ -11,7 +11,7 @@ interface CoinWebSocketProviderProps {
 }
 
 const CoinWebSocketProvider: React.FC<CoinWebSocketProviderProps> = ({ symbol, children }) => {
-    const [webSocketData, setWebSocketData] = useState<CandlestickData[]>([]);
+    const [webSocketData, setWebSocketData] = useState<CoinManagerData>({candleData: [], tradeHistory: []});
     const managerRef = useRef<CoinWebSocketManager | null>(null);
     
     useEffect(() => {

--- a/src/bitCoinChart/style/TradingHitory.module.scss
+++ b/src/bitCoinChart/style/TradingHitory.module.scss
@@ -1,0 +1,6 @@
+.table {
+    font-size: 14px;
+    table, td, th {
+        border: 1px solid #000000;
+    }
+}

--- a/src/bitCoinChart/style/chart.module.scss
+++ b/src/bitCoinChart/style/chart.module.scss
@@ -46,6 +46,18 @@
     padding: 2px;
 }
 
+.tab {
+    display: flex;
+    flex: 1;
+    font-size: 17px;
+    height: 30px;
+    font-weight: 800;
+    align-items: center;
+    justify-content: center;
+    padding: 2px;
+    border: 1px solid #000000;
+}
+
 .app {
     height: calc(100svh - 120px);
     display: flex;
@@ -88,8 +100,7 @@
     display: flex;
     gap: 24px;
     background: #242424;
-    padding: 16px;
+    padding: 4px;
     border-radius: 12px;
     box-shadow: 0 2px 8px rgba(248, 248, 248, 0.05);
-    max-width: 300px;
 }

--- a/src/bitCoinChart/types/CoinTypes.ts
+++ b/src/bitCoinChart/types/CoinTypes.ts
@@ -2,7 +2,7 @@ import { CandlestickData, Time } from "lightweight-charts";
 
 export const BINANCE_URL = 'wss://stream.binance.com:9443/ws/';
 
-export type Subscriber = (data: CandlestickData[]) => void;
+export type Subscriber = (data: CoinManagerData) => void;
 
 export type TradingData = {
     price: number,
@@ -13,4 +13,17 @@ export type CurrentPriceData = {
     price: number,
     color: string,
     openPrice: number,
+}
+
+export type TradeHistory = {
+    id: number,
+    price: number,
+    mount: number,
+    maker: boolean,
+    time: number,
+}
+
+export type CoinManagerData = {
+    candleData: CandlestickData[],
+    tradeHistory: TradeHistory[],
 }

--- a/src/bitCoinChart/utils/util.ts
+++ b/src/bitCoinChart/utils/util.ts
@@ -1,0 +1,8 @@
+export const convertKrTime = (ms: number) => {
+    return new Date(ms).toLocaleTimeString("ko-KR", {
+        hour12: false,
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+      });
+}

--- a/src/bitCoinChart/worker/CoinSharedWorker.js
+++ b/src/bitCoinChart/worker/CoinSharedWorker.js
@@ -1,108 +1,22 @@
+import { dataSetting, fetchAllOpenPrices, wsUrl } from "./WorkerUtils";
+
 // shared-worker.js
 const connections = [];
 const priceMap = {};
-const wsUrl = `wss://stream.binance.com:9443/ws/!ticker@arr`;
 let ws = null;
-let fillOpenPrice = false;
-
-const BINANCE_API_URL = "https://api.binance.com/api/v3";
-
-// 1. 모든 종목 리스트 가져오기 (USDT 페어만 필터링)
-async function getAllSymbols() {
-    try {
-        const response = await fetch(`${BINANCE_API_URL}/exchangeInfo`);
-        const data = await response.json();
-
-        if (!data.symbols) {
-            throw new Error("Failed to fetch symbols list");
-        }
-
-        // USDT 마켓에 해당하는 종목만 필터링
-        const symbols = data.symbols
-            .filter((s) => s.symbol.endsWith("USDT") && s.status === 'TRADING') // USDT 페어만 가져오기
-            .map((s) => s.symbol);
-
-        return symbols;
-    } catch (error) {
-        console.error("Error fetching symbols list:", error);
-        return [];
-    }
-}
-
-// 2. 특정 종목의 한국시간 9시 시가(open price) 가져오기
-async function getOpenPrice(symbol) {
-    const url = `${BINANCE_API_URL}/klines?symbol=${symbol}&interval=1d&limit=2`;
-
-    try {
-        const response = await fetch(url);
-        const data = await response.json();
-
-        if (!Array.isArray(data) || data.length < 2) {
-            throw new Error(`No sufficient data for ${symbol}`);
-        }
-
-        // 어제의 open price (1d 캔들의 시작가)
-        const openPrice = data.length >= 2 ? data[1][1] : data[0][1];
-        const curPrice = data.length >= 2 ? data[1][4] : data[0][4];
-
-        return { symbol, openPrice, curPrice };
-    } catch (error) {
-        console.error(`Error fetching data for ${symbol}:`, error);
-        return { symbol, openPrice: null , curPrice: null };
-    }
-}
-
-// 3. 모든 종목의 9시 시가 가져오기
-async function fetchAllOpenPrices() {
-    const symbols = await getAllSymbols();
-    
-    if (symbols.length === 0) {
-        console.error("No symbols available.");
-        return;
-    }
-
-    console.log(`Fetching open prices for ${symbols.length} symbols...`);
-
-    const results = await Promise.all(symbols.map(getOpenPrice));
-    results.forEach(x => {
-      let color = '#FFFFFF';
-      const curPrice = parseFloat(x.curPrice);
-      const openPrice = parseFloat(x.openPrice);
-      if (openPrice < curPrice) {
-        color = "#f75467";
-      } else if (openPrice > curPrice) {
-        color = "#4386f9";
-      }
-      priceMap[x.symbol] = {price: curPrice, color: color, openPrice: openPrice}
-    });
-}
 
 // websocket 실행 전에 호출해서 openPrice 세팅
-fetchAllOpenPrices();
+fetchAllOpenPrices(priceMap);
 
 
 const connectWebSocket = () => {
-  console.log('실행완료');
   ws = new WebSocket(wsUrl);
 
   ws.onmessage = (event) => { 
       const json = JSON.parse(event.data);
       const symbolFilterArr = Array.from(json).filter(x => x.s.includes("USDT"));
       try {
-        // 변경이 있는 데이터만 전송해주므로 따로 효율화 할 필요 없음
-        symbolFilterArr.forEach(x => {
-          if (priceMap[x.s]) {
-            let color = '#FFFFFF';
-            const curPrice = parseFloat(x.c);
-            if (priceMap[x.s].openPrice < curPrice) {
-              color = "#f75467";
-            } else if (priceMap[x.s].openPrice > curPrice) {
-              color = "#4386f9";
-            }
-            priceMap[x.s].price = curPrice;
-            priceMap[x.s].color = color;
-          }
-        });
+        dataSetting(symbolFilterArr, priceMap);
       } catch (e) {
         connections.forEach((port) => {
           port.postMessage('데이터 정리 오류');

--- a/src/bitCoinChart/worker/CoinWorker.js
+++ b/src/bitCoinChart/worker/CoinWorker.js
@@ -1,107 +1,21 @@
+import { dataSetting, fetchAllOpenPrices, wsUrl } from "./WorkerUtils";
+
 // shared-worker.js
 const priceMap = {};
-const wsUrl = `wss://stream.binance.com:9443/ws/!ticker@arr`;
 let ws = null;
-let fillOpenPrice = false;
-
-const BINANCE_API_URL = "https://api.binance.com/api/v3";
-
-// 1. 모든 종목 리스트 가져오기 (USDT 페어만 필터링)
-async function getAllSymbols() {
-    try {
-        const response = await fetch(`${BINANCE_API_URL}/exchangeInfo`);
-        const data = await response.json();
-
-        if (!data.symbols) {
-            throw new Error("Failed to fetch symbols list");
-        }
-
-        // USDT 마켓에 해당하는 종목만 필터링
-        const symbols = data.symbols
-            .filter((s) => s.symbol.endsWith("USDT") && s.status === 'TRADING') // USDT 페어만 가져오기
-            .map((s) => s.symbol);
-
-        return symbols;
-    } catch (error) {
-        console.error("Error fetching symbols list:", error);
-        return [];
-    }
-}
-
-// 2. 특정 종목의 한국시간 9시 시가(open price) 가져오기
-async function getOpenPrice(symbol) {
-    const url = `${BINANCE_API_URL}/klines?symbol=${symbol}&interval=1d&limit=2`;
-
-    try {
-        const response = await fetch(url);
-        const data = await response.json();
-
-        if (!Array.isArray(data) || data.length < 2) {
-            throw new Error(`No sufficient data for ${symbol}`);
-        }
-
-        // 어제의 open price (1d 캔들의 시작가)
-        const openPrice = data.length >= 2 ? data[1][1] : data[0][1];
-        const curPrice = data.length >= 2 ? data[1][4] : data[0][4];
-
-        return { symbol, openPrice, curPrice };
-    } catch (error) {
-        console.error(`Error fetching data for ${symbol}:`, error);
-        return { symbol, openPrice: null , curPrice: null };
-    }
-}
-
-// 3. 모든 종목의 9시 시가 가져오기
-async function fetchAllOpenPrices() {
-    const symbols = await getAllSymbols();
-    
-    if (symbols.length === 0) {
-        console.error("No symbols available.");
-        return;
-    }
-
-    console.log(`Fetching open prices for ${symbols.length} symbols...`);
-
-    const results = await Promise.all(symbols.map(getOpenPrice));
-    results.forEach(x => {
-      let color = '#FFFFFF';
-      const curPrice = parseFloat(x.curPrice);
-      const openPrice = parseFloat(x.openPrice);
-      if (openPrice < curPrice) {
-        color = "#f75467";
-      } else if (openPrice > curPrice) {
-        color = "#4386f9";
-      }
-      priceMap[x.symbol] = {price: curPrice, color: color, openPrice: openPrice}
-    });
-}
 
 // websocket 실행 전에 호출해서 openPrice 세팅
-fetchAllOpenPrices();
+fetchAllOpenPrices(priceMap);
 
 
 const connectWebSocket = () => {
-  console.log('실행완료');
   ws = new WebSocket(wsUrl);
 
   ws.onmessage = (event) => { 
       const json = JSON.parse(event.data);
       const symbolFilterArr = Array.from(json).filter(x => x.s.includes("USDT"));
       try {
-        // 변경이 있는 데이터만 전송해주므로 따로 효율화 할 필요 없음
-        symbolFilterArr.forEach(x => {
-          if (priceMap[x.s]) {
-            let color = '#FFFFFF';
-            const curPrice = parseFloat(x.c);
-            if (priceMap[x.s].openPrice < curPrice) {
-              color = "#f75467";
-            } else if (priceMap[x.s].openPrice > curPrice) {
-              color = "#4386f9";
-            }
-            priceMap[x.s].price = curPrice;
-            priceMap[x.s].color = color;
-          }
-        });
+        dataSetting(symbolFilterArr, priceMap);
       } catch (e) {
           self.postMessage('데이터 정리 오류');
       }

--- a/src/bitCoinChart/worker/WorkerUtils.js
+++ b/src/bitCoinChart/worker/WorkerUtils.js
@@ -1,0 +1,89 @@
+export const wsUrl = `wss://stream.binance.com:9443/ws/!ticker@arr`;
+
+export const BINANCE_API_URL = "https://api.binance.com/api/v3";
+
+// 1. 모든 종목 리스트 가져오기 (USDT 페어만 필터링)
+async function getAllSymbols() {
+    try {
+        const response = await fetch(`${BINANCE_API_URL}/exchangeInfo`);
+        const data = await response.json();
+
+        if (!data.symbols) {
+            throw new Error("Failed to fetch symbols list");
+        }
+
+        // USDT 마켓에 해당하는 종목만 필터링
+        const symbols = data.symbols
+            .filter((s) => s.symbol.endsWith("USDT") && s.status === 'TRADING') // USDT 페어만 가져오기
+            .map((s) => s.symbol);
+
+        return symbols;
+    } catch (error) {
+        console.error("Error fetching symbols list:", error);
+        return [];
+    }
+}
+
+// 2. 특정 종목의 한국시간 9시 시가(open price) 가져오기
+async function getOpenPrice(symbol) {
+    const url = `${BINANCE_API_URL}/klines?symbol=${symbol}&interval=1d&limit=2`;
+
+    try {
+        const response = await fetch(url);
+        const data = await response.json();
+
+        if (!Array.isArray(data) || data.length < 2) {
+            throw new Error(`No sufficient data for ${symbol}`);
+        }
+
+        // 어제의 open price (1d 캔들의 시작가)
+        const openPrice = data.length >= 2 ? data[1][1] : data[0][1];
+        const curPrice = data.length >= 2 ? data[1][4] : data[0][4];
+
+        return { symbol, openPrice, curPrice };
+    } catch (error) {
+        console.error(`Error fetching data for ${symbol}:`, error);
+        return { symbol, openPrice: null , curPrice: null };
+    }
+}
+
+// 3. 모든 종목의 9시 시가 가져오기
+export async function fetchAllOpenPrices(priceMap) {
+    const symbols = await getAllSymbols();
+    
+    if (symbols.length === 0) {
+        console.error("No symbols available.");
+        return;
+    }
+
+    console.log(`Fetching open prices for ${symbols.length} symbols...`);
+
+    const results = await Promise.all(symbols.map(getOpenPrice));
+    results.forEach(x => {
+      let color = '#FFFFFF';
+      const curPrice = parseFloat(x.curPrice);
+      const openPrice = parseFloat(x.openPrice);
+      if (openPrice < curPrice) {
+        color = "#f75467";
+      } else if (openPrice > curPrice) {
+        color = "#4386f9";
+      }
+      priceMap[x.symbol] = {price: curPrice, color: color, openPrice: openPrice}
+    });
+}
+
+export function dataSetting(symbolFilterArr, priceMap) {
+    symbolFilterArr.forEach(x => {
+        if (priceMap[x.s]) {
+          let color = '#FFFFFF';
+          const curPrice = parseFloat(x.c);
+          if (priceMap[x.s].openPrice < curPrice) {
+            color = "#f75467";
+          } else if (priceMap[x.s].openPrice > curPrice) {
+            color = "#4386f9";
+          }
+          priceMap[x.s].price = curPrice;
+          priceMap[x.s].color = color;
+        }
+    });
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -11,7 +11,6 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  width: calc(100vw - 17px);
 }
 
 * {
@@ -41,7 +40,9 @@
 }
 
 body {
-  display: block; 
+  display: block;
+  width: 100%;
+  margin: 0;
 }
 
 header {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,10 @@ export default defineConfig({
       const version = Date.now(); // 또는 `git rev-parse --short HEAD`
       return html.replace(/style.scss/g, `style.css?v=${version}`)
                  .replace(/script.js/g, `script.js?v=${version}`);
-    }
+    },
   }],
+  server: {
+    host: true,
+    port: 5173,
+  },
 })


### PR DESCRIPTION
- 1. 차트프로젝트 모바일 탭기능 추가 (화면이 작으므로 탭단위로 볼수있도록 구성)
- 2. 탭 목록: 차트, 호가, 시세
- 3. 시세 기능 추가 (실시간 체결량, 가격, 시간)
- 코드정리 및 일부 재사용 가능 코드 일부 유틸함수로 묶음
- 스타일 정리
- websocket Manager에서 tradeHitory 데이터도 저장하고 퍼블리싱 하도록 처리
- managerContext 반환값 타입 변경 {candleData, tradeHitory}
- tradehistory는 최대 50개 항목만 유지하도록 처리