### PR TITLE
[bugfix] 모듈안에서 worker를 생성하도록 처리

### DIFF
--- a/src/bitCoinChart/hooks/SymbolContextProvider.tsx
+++ b/src/bitCoinChart/hooks/SymbolContextProvider.tsx
@@ -41,12 +41,11 @@ const createUpbitWorker = () => {
   }
 };
 
-const worker = createWorker();
-const upbitWorker = createUpbitWorker();
-
 const SymbolContextProvider = ({ children }: { children: ReactNode }) => {
   const [symbol, setSymbol] = useState<string>('ADAUSDT');
   const [symbolList, setSymbolList] = useState<string[]>([]);
+  const [worker] = useState(() => createWorker());
+  const [upbitWorker] = useState(() => createUpbitWorker());
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
- module 최상단에 있을때 호출하게되면 모듈 Import시점에 실행되므로 sharedworker를 참조하게됨됨