### PR TITLE
[feat] worker, sharedworker message 효율화

### DIFF
--- a/src/bitCoinChart/hooks/SymbolContextProvider.tsx
+++ b/src/bitCoinChart/hooks/SymbolContextProvider.tsx
@@ -61,9 +61,9 @@ const SymbolContextProvider = ({ children }: { children: ReactNode }) => {
       const data = event.data;
       // data type이 'symbolData' 인 경우에만 react-query data로 적재
       if (data?.type === WorkerMessageEnum.UPBIT_SYMBOL_TRADE_DATA) {
-        console.log(event.data);
-        queryClient.setQueryData(['symbol', data.data.symbol], data.data);
-        console.log(event.data);
+        Object.entries(data.data).forEach(([symbol, data]) => {
+          queryClient.setQueryData(['symbol', symbol], data);
+        });
       } else if (data?.type === WorkerMessageEnum.UPBIT_SYMBOLS_RESTAPI_TRADE_DATA) {
         Object.entries(data.data).forEach(([symbol, data]) => {
           queryClient.setQueryData(['symbol', symbol], data);

--- a/src/bitCoinChart/worker/WorkerUtils.ts
+++ b/src/bitCoinChart/worker/WorkerUtils.ts
@@ -6,7 +6,8 @@ let region = '';
 
 export function dataSetting<T extends BinanceTickerData | UpbitTickerData>(
   symbolFilterArr: T[],
-  priceMap: PriceMap
+  priceMap: PriceMap,
+  newMessageMap: PriceMap
 ) {
   symbolFilterArr.forEach((x) => {
     const { symbol, price: curPrice, openPrice } = getSymbolAndPrice(x);
@@ -17,6 +18,11 @@ export function dataSetting<T extends BinanceTickerData | UpbitTickerData>(
       priceMap[symbol].color = color;
       if (openPrice) {
         priceMap[symbol].openPrice = openPrice;
+      }
+
+      // 쓰로틀링 단위 시간동안 같은 symbol데이터가 여러번 들어왔을때 반복 처리하지않고 없는 경우 포인터만 한번 연결함으로써 자동추적되도록 처리
+      if (!newMessageMap[symbol]) {
+        newMessageMap[symbol] = priceMap[symbol];
       }
     }
   });

--- a/src/bitCoinChart/worker/binance/BinanceSharedWorker.ts
+++ b/src/bitCoinChart/worker/binance/BinanceSharedWorker.ts
@@ -5,12 +5,16 @@ import { fetchBinanceAllOpenPrices } from './BinanceWorkerUtils';
 import { dataSetting, isUsCountry } from '../WorkerUtils';
 import { BINANCE_WEBSOCKET_URL, BINANCE_WEBSOCKET_US_URL } from '../../types/CoinTypes';
 import { WorkerMessageEnum } from '../enum/WorkerMessageEnum';
+import { PriceMap } from '../CoinCommonTypes';
 
 const sharedWorkerGlobal = self as unknown as SharedWorkerGlobalScope;
 
 const connections: MessagePort[] = [];
-const priceMap = {};
+const priceMap: PriceMap = {};
 let ws = null;
+let timer: number | null = null;
+// 쓰로틀링 처리 과정에서 priceMap 을 전체 client에서 할일이 많아지기 때문에 worker에서 변동 내역만 보내주기위함
+let newMessageMap: PriceMap = {};
 
 // websocket 실행 전에 호출해서 openPrice 세팅
 fetchBinanceAllOpenPrices(priceMap);
@@ -24,16 +28,24 @@ const connectWebSocket = (url: string) => {
       x.s.includes('USDT')
     );
     try {
-      dataSetting(symbolFilterArr, priceMap);
+      dataSetting(symbolFilterArr, priceMap, newMessageMap);
     } catch (e) {
       connections.forEach((port) => {
         port.postMessage(`데이터 정리 오류: ${e}`);
       });
     }
 
-    connections.forEach((port) => {
-      port.postMessage({ type: WorkerMessageEnum.BINANCE_SYMBOLS_DATA, data: priceMap });
-    });
+    if (!timer) {
+      timer = setTimeout(() => {
+        connections.forEach((port) => {
+          port.postMessage({ type: WorkerMessageEnum.BINANCE_SYMBOLS_DATA, data: newMessageMap });
+        });
+
+        // messageMap 초기화하여 다음 쓰로틀 처리 이벤트까지 새로운 객체에 담음
+        newMessageMap = {};
+        timer = null;
+      }, 300);
+    }
   };
 
   ws.onclose = () => {

--- a/src/bitCoinChart/worker/binance/BinanceWorker.ts
+++ b/src/bitCoinChart/worker/binance/BinanceWorker.ts
@@ -3,9 +3,13 @@ import { fetchBinanceAllOpenPrices } from './BinanceWorkerUtils';
 import { dataSetting, isUsCountry } from '../WorkerUtils';
 import { BINANCE_WEBSOCKET_URL, BINANCE_WEBSOCKET_US_URL } from '../../types/CoinTypes';
 import { WorkerMessageEnum } from '../enum/WorkerMessageEnum';
+import { PriceMap } from '../CoinCommonTypes';
 
-const priceMap = {};
+const priceMap: PriceMap = {};
 let ws = null;
+let timer: number | null = null;
+// 쓰로틀링 처리 과정에서 priceMap 을 전체 client에서 할일이 많아지기 때문에 worker에서 변동 내역만 보내주기위함
+let newMessageMap: PriceMap = {};
 
 // websocket 실행 전에 호출해서 openPrice 세팅
 fetchBinanceAllOpenPrices(priceMap);
@@ -17,11 +21,19 @@ const connectWebSocket = (url: string) => {
     const json = JSON.parse(event.data) as BinanceTickerData[];
     const symbolFilterArr = Array.from(json).filter((x) => x.s.includes('USDT'));
     try {
-      dataSetting(symbolFilterArr, priceMap);
+      dataSetting(symbolFilterArr, priceMap, newMessageMap);
     } catch (e) {
       self.postMessage(`데이터 정리 오류: ${e}`);
     }
-    self.postMessage({ type: WorkerMessageEnum.BINANCE_SYMBOLS_DATA, data: priceMap });
+    if (!timer) {
+      timer = setTimeout(() => {
+        self.postMessage({ type: WorkerMessageEnum.BINANCE_SYMBOLS_DATA, data: newMessageMap });
+
+        // messageMap 초기화하여 다음 쓰로틀 처리 이벤트까지 새로운 객체에 담음
+        newMessageMap = {};
+        timer = null;
+      }, 300);
+    }
   };
 
   ws.onclose = () => {


### PR DESCRIPTION
- 워커에서 websocket  서버로부터 받은 메세지를 적재해놓고 변경된 부분만 체크해서 클라이언트로 보내주도록처리
- worker에서 데이터를 수신할때마다 클라이언트로 데이터를 브로드캐스트 하던 로직을 쓰로틀링 처리하여 300ms 마다 보내도록 처리
- 측정결과 300ms 내에 worker webscoket은 약 10~30 번 메세지를 주입받기 때문에 메세지를 newMessageMap에 적재해놓고 300ms마다 전송하도록 처리
- 처리 방식이 변경되어 클라이언트 worker onMessage 처리방식 일부 수정