### PR TITLE
[feat] 코인리스트를 24시간 거래량 기준으로 정렬되어 나타나도로처리

### DIFF
--- a/src/bitCoinChart/hooks/SymbolContextProvider.tsx
+++ b/src/bitCoinChart/hooks/SymbolContextProvider.tsx
@@ -47,9 +47,11 @@ const SymbolContextProvider = ({ children }: { children: ReactNode }) => {
 
         // symbolList가 구성되어있지 않았을때만 setting
         if (isListInit.current === false) {
-          const symbols = Object.keys(data.data);
+          const symbols = Object.keys(data.data).sort(
+            (a, b) => data.data[b].asset - data.data[a].asset
+          );
           if (symbols.length > 0) {
-            setSymbolList(Object.keys(data.data));
+            setSymbolList(symbols);
             isListInit.current = true;
           }
         }

--- a/src/bitCoinChart/worker/binance/type/BinanceWorkerTypes.ts
+++ b/src/bitCoinChart/worker/binance/type/BinanceWorkerTypes.ts
@@ -1,4 +1,5 @@
 export interface BinanceTickerData {
   s: string;
   c: string;
+  q: string;
 }

--- a/src/bitCoinChart/worker/binance/util/BinanceWorkerUtils.ts
+++ b/src/bitCoinChart/worker/binance/util/BinanceWorkerUtils.ts
@@ -50,11 +50,12 @@ async function getBinanceOpenPrice(symbol: string) {
     // 어제의 open price (1d 캔들의 시작가)
     const openPrice = data.length >= 2 ? data[1][1] : data[0][1];
     const curPrice = data.length >= 2 ? data[1][4] : data[0][4];
+    const asset = data[0][7];
 
-    return { symbol, openPrice, curPrice };
+    return { symbol, openPrice, curPrice, asset };
   } catch (error) {
     console.error(`Error fetching data for ${symbol}:`, error);
-    return { symbol, openPrice: null, curPrice: null };
+    return { symbol, openPrice: null, curPrice: null, asset: null };
   }
 }
 
@@ -74,11 +75,12 @@ export async function fetchBinanceAllOpenPrices(priceMap: PriceMap) {
     let color = '#FFFFFF';
     const curPrice = parseFloat(x.curPrice);
     const openPrice = parseFloat(x.openPrice);
+    const asset = parseFloat(x.asset);
     if (openPrice < curPrice) {
       color = '#f75467';
     } else if (openPrice > curPrice) {
       color = '#4386f9';
     }
-    priceMap[x.symbol] = { price: curPrice, color: color, openPrice: openPrice };
+    priceMap[x.symbol] = { price: curPrice, color: color, openPrice: openPrice, asset };
   });
 }

--- a/src/bitCoinChart/worker/type/CoinCommonTypes.ts
+++ b/src/bitCoinChart/worker/type/CoinCommonTypes.ts
@@ -2,6 +2,7 @@ export type PriceData = {
   price: number;
   openPrice: number;
   color: string;
+  asset: number;
 };
 
 export type PriceMap = {

--- a/src/bitCoinChart/worker/upbit/util/UpbitWorkerUtils.ts
+++ b/src/bitCoinChart/worker/upbit/util/UpbitWorkerUtils.ts
@@ -27,6 +27,6 @@ export async function fetchUpbitAllOpenPrices(priceMap: PriceMap, symbols: Upbit
   console.log(`Fetching open prices for ${symbols.length} symbols...`);
 
   symbols.forEach((x) => {
-    priceMap[x.market] = { price: 0, color: '#FFFFFF', openPrice: 0 };
+    priceMap[x.market] = { price: 0, color: '#FFFFFF', openPrice: 0, asset: 0 };
   });
 }

--- a/src/bitCoinChart/worker/util/WorkerUtils.ts
+++ b/src/bitCoinChart/worker/util/WorkerUtils.ts
@@ -10,12 +10,13 @@ export function dataSetting<T extends BinanceTickerData | UpbitTickerData>(
   newMessageMap: PriceMap
 ) {
   symbolFilterArr.forEach((x) => {
-    const { symbol, price: curPrice, openPrice } = getSymbolAndPrice(x);
+    const { symbol, price: curPrice, asset, openPrice } = getSymbolAndPrice(x);
 
     if (priceMap[symbol]) {
       const color = getPriceColor(priceMap[symbol].openPrice, curPrice);
       priceMap[symbol].price = curPrice;
       priceMap[symbol].color = color;
+      priceMap[symbol].asset = asset;
       if (openPrice) {
         priceMap[symbol].openPrice = openPrice;
       }
@@ -31,14 +32,16 @@ export function dataSetting<T extends BinanceTickerData | UpbitTickerData>(
 function getSymbolAndPrice(item: BinanceTickerData | UpbitTickerData): {
   symbol: string;
   price: number;
+  asset: number;
   openPrice?: number;
 } {
   if ('s' in item && 'c' in item) {
-    return { symbol: item.s, price: parseFloat(item.c) }; // Binance
+    return { symbol: item.s, price: parseFloat(item.c), asset: parseFloat(item.q) }; // Binance
   } else if ('code' in item && 'trade_price' in item) {
     return {
       symbol: item.code,
       price: item.trade_price,
+      asset: item.acc_trade_price_24h,
       openPrice: item.opening_price,
     }; // Upbit
   } else {


### PR DESCRIPTION
- 바이낸스에서 가져와 처리할경우 map 으로 반환하여 순서를 보장할수없어 asset기준으로 sort되도록 추가